### PR TITLE
Add noexcept

### DIFF
--- a/include/ros_type_introspection/ros_type.hpp
+++ b/include/ros_type_introspection/ros_type.hpp
@@ -179,7 +179,7 @@ namespace std {
     typedef RosIntrospection::ROSType argument_type;
     typedef std::size_t               result_type;
 
-    result_type operator()(RosIntrospection::ROSType const& type) const
+    result_type operator()(RosIntrospection::ROSType const& type) const noexcept
     {
       return type.hash();
     }

--- a/include/ros_type_introspection/substitution_rule.hpp
+++ b/include/ros_type_introspection/substitution_rule.hpp
@@ -151,7 +151,7 @@ namespace std {
     typedef RosIntrospection::SubstitutionRule argument_type;
     typedef std::size_t                        result_type;
 
-    result_type operator()(RosIntrospection::SubstitutionRule const& sr) const
+    result_type operator()(RosIntrospection::SubstitutionRule const& sr) const noexcept
     {
       return sr.hash();
     }


### PR DESCRIPTION
This PR will fix an error on compiling with this library (Ubuntu 24.04 / ROS-O):

```
/opt/ros/one/include/ros_type_introspection/ros_introspection.hpp:249:69:   required from here
/usr/include/c++/13/type_traits:3024:14: error: noexcept-expression evaluates to 'false' because of a call to 'std::hash<RosIntrospection::ROSType>::result_type std::hash<RosIntrospection::ROSType>::operator()(const RosIntrospection::ROSType&) const' [-Werror=noexcept]
```