### PR TITLE
Suppress warning about std::not1

### DIFF
--- a/src/ros_message.cpp
+++ b/src/ros_message.cpp
@@ -59,8 +59,9 @@ ROSMessage::ROSMessage(const std::string &msg_def)
     }
 
     // Trim start of line
-    line.erase(line.begin(), std::find_if(line.begin(), line.end(),
-      std::not1(std::ptr_fun<int, int>(std::isspace))));
+    line.erase(line.begin(),
+	       std::find_if(line.begin(), line.end(),
+			    [](const char c){ return !std::isspace(c); }));
 
     if( line.compare(0, 5, "MSG: ") == 0)
     {


### PR DESCRIPTION
This PR suppresses a warning message on compiling this library (Ubuntu 24.04 / ROS-O):

```
[ros_type_introspection:make] In file included from /usr/include/c++/13/string:49,
[ros_type_introspection:make]                  from /usr/include/boost/algorithm/string/std/string_traits.hpp:15,
[ros_type_introspection:make]                  from /usr/include/boost/algorithm/string/std_containers_traits.hpp:19,
[ros_type_introspection:make]                  from /usr/include/boost/algorithm/string.hpp:18,
[ros_type_introspection:make]                  from /home/gitai/gitai/catkin_ws/src/ros_type_introspection/src/ros_message.cpp:36:
[ros_type_introspection:make] /usr/include/c++/13/bits/stl_function.h:1126:5: note: declared here
[ros_type_introspection:make] /catkin_ws/src/ros_type_introspection/src/ros_message.cpp:63:16: warning: 'constexpr std::unary_negate<_Predicate> std::not1(const _Predicate&) [with _Predicate = pointer_to_unary_function<int, int>]' is deprecated: use 'std::not_fn' instead [-Wdeprecated-declarations]
[ros_type_introspection:make]    63 | namespace std
[ros_type_introspection:make]       |       ~~~~~~~  ^                                     
```